### PR TITLE
Add coins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "idlecoin"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlecoin"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,17 @@
 use crate::*;
+use std::collections::HashMap;
+
+#[derive(PartialEq, Eq, Hash)]
+enum PurchaseType {
+    Boost,
+    Miner,
+}
+
+#[derive(Copy, Clone, PartialEq, Hash)]
+struct Purchase {
+    bought: usize,
+    cost: u128,
+}
 
 pub fn read_inputs(
     connections: &Arc<Mutex<Vec<Connection>>>,
@@ -14,6 +27,7 @@ pub fn read_inputs(
             Err(_) => continue,
         };
 
+        // Server terminal output
         if len > 0 {
             println!(
                 "> User: 0x{:016x} Miner 0x{:08x} sent: {:?} from: {:?}",
@@ -22,24 +36,31 @@ pub fn read_inputs(
                 &buf[..len],
                 c.stream
             );
+        } else {
+            continue;
         }
 
-        let mut new_boost = 0;
-        let mut new_boost_cost = 0u128;
-        let mut new_miners = 0;
-        let mut new_miners_cost = 0u128;
+        let mut upgrades = HashMap::new();
 
-        for i in buf[..len].iter() {
+        // Iterate through each char in the received buffer
+        'nextchar: for i in buf[..len].iter() {
             if *i == b'b' {
                 // Purchase boost
                 let mut wals = wallets.lock().unwrap();
                 for w in wals.iter_mut() {
                     if w.id == c.miner.wallet_id {
-                        let cost = buy_boost(c, w);
-                        if cost > 0 {
-                            new_boost += 128;
-                            new_boost_cost += cost as u128;
-                        }
+                        let cost = match buy_boost(c, w) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                c.updates.push(e.to_string());
+                                continue 'nextchar;
+                            }
+                        };
+                        let new = Purchase {
+                            bought: 128,
+                            cost: cost as u128,
+                        };
+                        update_upgrade_list(&mut upgrades, PurchaseType::Boost, new);
                     }
                 }
                 drop(wals);
@@ -49,42 +70,66 @@ pub fn read_inputs(
                 let mut wals = wallets.lock().unwrap();
                 for w in wals.iter_mut() {
                     if w.id == c.miner.wallet_id {
-                        let cost = buy_miner(c, w);
-                        if cost > 0 {
-                            new_miners += 1;
-                            new_miners_cost += cost as u128;
-                        }
+                        let cost = match buy_miner(w) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                c.updates.push(e.to_string());
+                                continue 'nextchar;
+                            }
+                        };
+                        let new = Purchase {
+                            bought: 1,
+                            cost: cost as u128,
+                        };
+                        update_upgrade_list(&mut upgrades, PurchaseType::Miner, new);
                     }
                 }
                 drop(wals);
             }
         }
-        let t: DateTime<Local> = Local::now();
-        if new_boost > 0 {
-            msg.insert(
-                0,
-                format!(
-                    " [{}] Miner 0x{:08x} bought {} boost seconds with {} idlecoin\n",
-                    t.format("%Y-%m-%d %H:%M:%S"),
-                    c.miner.miner_id,
-                    new_boost,
-                    new_boost_cost,
+
+        // Purchase notification updates
+        for (k, p) in upgrades.iter() {
+            let t: DateTime<Local> = Local::now();
+            match k {
+                PurchaseType::Boost => msg.insert(
+                    0,
+                    format!(
+                        " [{}] Miner 0x{:08x} bought {} boost seconds with {} idlecoin\n",
+                        t.format("%Y-%m-%d %H:%M:%S"),
+                        c.miner.miner_id,
+                        p.bought,
+                        p.cost,
+                    ),
                 ),
-            );
-        }
-        if new_miners > 0 {
-            msg.insert(
-                0,
-                format!(
-                    " [{}] Wallet 0x{:016x} bought new miner license(s) with {} idlecoin\n",
-                    t.format("%Y-%m-%d %H:%M:%S"),
-                    c.miner.wallet_id,
-                    new_miners_cost
+                PurchaseType::Miner => msg.insert(
+                    0,
+                    format!(
+                        " [{}] Wallet 0x{:016x} bought {} new miner license(s) with {} idlecoin\n",
+                        t.format("%Y-%m-%d %H:%M:%S"),
+                        c.miner.wallet_id,
+                        p.bought,
+                        p.cost,
+                    ),
                 ),
-            );
+            }
         }
     }
     drop(cons);
+}
+
+fn update_upgrade_list(
+    map: &mut HashMap<PurchaseType, Purchase>,
+    p_type: PurchaseType,
+    p: Purchase,
+) {
+    let mut node = match map.get(&p_type) {
+        Some(n) => *n,
+        None => Purchase { bought: 0, cost: 0 },
+    };
+    node.bought += p.bought;
+    node.cost += p.cost;
+    map.insert(p_type, node);
 }
 
 pub fn boost_cost(cps: u64) -> u64 {
@@ -92,30 +137,29 @@ pub fn boost_cost(cps: u64) -> u64 {
     1u64.checked_shl(v).unwrap_or(0)
 }
 
-fn buy_boost(connection: &mut Connection, wallet: &mut Wallet) -> u64 {
+fn buy_boost(connection: &mut Connection, wallet: &mut Wallet) -> Result<u64, Error> {
     if connection.miner.cps < 1024 {
-        connection
-            .updates
-            .push("You need at least 1024 Cps to be able to purchase boost\n".to_string());
-        return 0;
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "You need at least 1024 Cps to be able to purchase boost\n",
+        ));
     }
     if connection.miner.boost > u16::MAX as u64 {
-        connection
-            .updates
-            .push("You cannot purchase any more boost right now\n".to_string());
-        return 0;
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "You cannot purchase any more boost right now\n",
+        ));
     }
     let cost = boost_cost(connection.miner.cps);
-    let boost = 128u64;
     if wallet.sub_idlecoins(cost).is_err() {
-        connection
-            .updates
-            .push("You do not have the funds to purchase boost\n".to_string());
-        return 0;
-    };
-    connection.miner.boost = connection.miner.boost.saturating_add(boost);
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "You do not have the funds to purchase boost\n",
+        ));
+    }
+    connection.miner.boost = connection.miner.boost.saturating_add(128);
 
-    cost
+    Ok(cost)
 }
 
 pub fn miner_cost(max_miners: u64) -> u64 {
@@ -126,22 +170,22 @@ pub fn miner_cost(max_miners: u64) -> u64 {
     }
 }
 
-fn buy_miner(connection: &mut Connection, mut wallet: &mut Wallet) -> u64 {
+fn buy_miner(mut wallet: &mut Wallet) -> Result<u64, Error> {
     if wallet.max_miners >= ABS_MAX_MINERS {
-        connection
-            .updates
-            .push("You cannot purchase any more miners\n".to_string());
-        return 0;
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "You cannot purchase any more miners\n",
+        ));
     }
 
     let cost = miner_cost(wallet.max_miners);
     if wallet.sub_idlecoins(cost).is_err() {
-        connection
-            .updates
-            .push("You do not have the funds to purchase a miner\n".to_string());
-        return 0;
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "You do not have the funds to purchase a miner\n",
+        ));
     };
     wallet.max_miners += 1;
 
-    cost
+    Ok(cost)
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -113,7 +113,7 @@ fn buy_boost(connection: &mut Connection, wallet: &mut Wallet) -> u64 {
         return 0;
     }
     let boost = 128u64;
-    miner::sub_idlecoins(wallet, cost);
+    wallet.sub_idlecoins(cost);
     connection.miner.boost = connection.miner.boost.saturating_add(boost);
 
     cost
@@ -137,7 +137,7 @@ fn buy_miner(connection: &mut Connection, mut wallet: &mut Wallet) -> u64 {
 
     let cost = miner_cost(wallet.max_miners);
     if wallet.idlecoin > cost || wallet.supercoin > 0 {
-        miner::sub_idlecoins(wallet, cost);
+        wallet.sub_idlecoins(cost);
         wallet.max_miners += 1;
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -106,14 +106,13 @@ fn buy_boost(connection: &mut Connection, wallet: &mut Wallet) -> u64 {
         return 0;
     }
     let cost = boost_cost(connection.miner.cps);
-    if wallet.idlecoin < cost && wallet.supercoin == 0 {
+    let boost = 128u64;
+    if wallet.sub_idlecoins(cost).is_err() {
         connection
             .updates
             .push("You do not have the funds to purchase boost\n".to_string());
         return 0;
-    }
-    let boost = 128u64;
-    wallet.sub_idlecoins(cost);
+    };
     connection.miner.boost = connection.miner.boost.saturating_add(boost);
 
     cost
@@ -136,10 +135,13 @@ fn buy_miner(connection: &mut Connection, mut wallet: &mut Wallet) -> u64 {
     }
 
     let cost = miner_cost(wallet.max_miners);
-    if wallet.idlecoin > cost || wallet.supercoin > 0 {
-        wallet.sub_idlecoins(cost);
-        wallet.max_miners += 1;
-    }
+    if wallet.sub_idlecoins(cost).is_err() {
+        connection
+            .updates
+            .push("You do not have the funds to purchase a miner\n".to_string());
+        return 0;
+    };
+    wallet.max_miners += 1;
 
     cost
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,13 +299,13 @@ fn increment_chrono(connections: &Arc<Mutex<Vec<Connection>>>, wallets: &Arc<Mut
 }
 
 fn increment_rando(connections: &Arc<Mutex<Vec<Connection>>>, wallets: &Arc<Mutex<Vec<Wallet>>>) {
-    let mut gens = wallets.lock().unwrap();
-    let cons = connections.lock().unwrap();
-
     let mut live_wallets = HashMap::new();
+
+    let cons = connections.lock().unwrap();
     for c in cons.iter() {
         live_wallets.insert(c.miner.wallet_id as u64, 1);
     }
+    drop(cons);
 
     let mut rng = rand::thread_rng();
     let random: usize = rng.gen();
@@ -319,6 +319,9 @@ fn increment_rando(connections: &Arc<Mutex<Vec<Connection>>>, wallets: &Arc<Mute
         }
     }
 
+    println!("[^] 0x{:016x} won 16 randocoins", winner_id);
+
+    let mut gens = wallets.lock().unwrap();
     for w in gens.iter_mut() {
         if w.id == winner_id {
             w.inc_randocoins();
@@ -400,15 +403,15 @@ fn print_wallets(
         }
 
         let wal = &format!(
-            "[{:03}] Wallet 0x{:016x} Coins: {}:{} Miner Licenses: {} Total Cps: {} Chronocoin: {} Randocoin: {}\n",
+            "[{:03}] Wallet 0x{:016x} Miner Licenses: {} Chronocoin: {} Randocoin: {} Coins: {}:{} Total Cps: {}\n",
             gens.len() - i,
             g.id,
-            g.supercoin,
-            g.idlecoin,
             g.max_miners,
-            total_cps,
             g.chronocoin,
             g.randocoin,
+            g.supercoin,
+            g.idlecoin,
+            total_cps,
         )
         .to_owned();
 
@@ -416,6 +419,7 @@ fn print_wallets(
             msg += wal;
             msg += "  [*] Miners:\n";
             msg += &min;
+            msg += "\n";
         }
     }
     drop(cons);

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ mod file;
 mod miner;
 mod wallet;
 
-use crate::wallet::Wallet;
+use crate::miner::*;
+use crate::wallet::*;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const CLR: &str = "\x1b[2J\x1b[;H";
@@ -46,17 +47,6 @@ const BANNER: &str = "
 Source: https://github.com/genonullfree/idlecoin
 
 Please enter your username: ";
-
-#[derive(Copy, Clone, Debug)]
-pub struct Miner {
-    miner_id: u32,  // miner address ID
-    wallet_id: u64, // wallet address ID
-    level: u64,     // current level
-    cps: u64,       // coin-per-second
-    inc: u64,       // Incrementor value
-    pow: u64,       // Next level up value
-    boost: u64,     // Seconds of boosted cps
-}
 
 #[derive(Debug)]
 pub struct Connection {
@@ -282,15 +272,7 @@ fn login(
     );
 
     // Create new Miner
-    Ok(Miner {
-        miner_id,
-        wallet_id,
-        level: 0,
-        cps: 0,
-        inc: 1,
-        pow: 10,
-        boost: 0,
-    })
+    Ok(Miner::new(wallet_id, miner_id))
 }
 
 fn print_wallets(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,9 @@ use xxhash_rust::xxh3;
 mod commands;
 mod file;
 mod miner;
+mod wallet;
+
+use crate::wallet::Wallet;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const CLR: &str = "\x1b[2J\x1b[;H";
@@ -43,14 +46,6 @@ const BANNER: &str = "
 Source: https://github.com/genonullfree/idlecoin
 
 Please enter your username: ";
-
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub struct Wallet {
-    id: u64,         // wallet address ID
-    supercoin: u64,  // supercoin
-    idlecoin: u64,   // idlecoin
-    max_miners: u64, // max number of miners
-}
 
 #[derive(Copy, Clone, Debug)]
 pub struct Miner {
@@ -245,12 +240,7 @@ fn login(
         }
     }
     if !found {
-        wals.push(Wallet {
-            id: wallet_id,
-            supercoin: 0,
-            idlecoin: 0,
-            max_miners,
-        });
+        wals.push(Wallet::new(wallet_id));
     }
     drop(wals);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,9 @@ fn print_wallets(
                         ));
                     }
                 }
+                if g.chronocoin > commands::time_cost() {
+                    c.purchases.push(format!("'c'<enter>\tPurchase 60m of time travel for this miner for {} chronocoins\n", commands::time_cost()));
+                }
 
                 // Build miner display
                 miner_line.push(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::io::{Error, ErrorKind};
 use std::io::{Read, Write};
 use std::net::Ipv4Addr;
-use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -125,10 +125,6 @@ fn main() -> Result<(), Error> {
                             Err(e) => println!("Failed to send: {e}"),
                         };
                     }
-                    match s.shutdown(Shutdown::Both) {
-                        Ok(_) => (),
-                        Err(e) => println!("Failed to shutdown: {e}"),
-                    };
                     continue;
                 }
             };

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -31,7 +31,9 @@ pub fn action_miners(
                 if w.id == c.miner.wallet_id {
                     w.supercoin -= w.supercoin.saturating_div(10);
                     let coins = w.idlecoin.saturating_div(10);
-                    w.sub_idlecoins(coins);
+                    if w.sub_idlecoins(coins).is_err() {
+                        continue;
+                    };
                     msg.insert(
                         0,
                         format!(

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -136,6 +136,7 @@ impl Miner {
         self.pow = self.pow.saturating_div(10);
     }
 }
+
 pub fn miner_session(mut miner: &mut Miner) {
     // Level up
     if miner.cps >= miner.pow {

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -1,5 +1,16 @@
 use crate::*;
 
+#[derive(Copy, Clone, Debug)]
+pub struct Miner {
+    pub miner_id: u32,  // miner address ID
+    pub wallet_id: u64, // wallet address ID
+    pub level: u64,     // current level
+    pub cps: u64,       // coin-per-second
+    inc: u64,           // Incrementor value
+    pow: u64,           // Next level up value
+    pub boost: u64,     // Seconds of boosted cps
+}
+
 pub fn action_miners(
     connections: &Arc<Mutex<Vec<Connection>>>,
     wallets: &Arc<Mutex<Vec<Wallet>>>,
@@ -20,7 +31,7 @@ pub fn action_miners(
                 if w.id == c.miner.wallet_id {
                     w.supercoin -= w.supercoin.saturating_div(10);
                     let coins = w.idlecoin.saturating_div(10);
-                    sub_idlecoins(w, coins);
+                    w.sub_idlecoins(coins);
                     msg.insert(
                         0,
                         format!(
@@ -35,7 +46,7 @@ pub fn action_miners(
         } else if x % 10000 == 0 {
             // 0.01 % chance
             let level = c.miner.level;
-            dec_level(&mut c.miner);
+            c.miner.dec_level();
             if level != c.miner.level {
                 msg.insert(
                     0,
@@ -49,7 +60,7 @@ pub fn action_miners(
         } else if x % 10000 <= 2 {
             // 0.02 % chance
             let level = c.miner.level;
-            inc_level(&mut c.miner);
+            c.miner.inc_level();
             if level != c.miner.level {
                 msg.insert(
                     0,
@@ -90,7 +101,7 @@ pub fn process_miners(
         // Update appropriate wallet
         for w in wals.iter_mut() {
             if c.miner.wallet_id == w.id {
-                add_idlecoins(w, c.miner.cps);
+                w.add_idlecoins(c.miner.cps);
             }
         }
     }
@@ -98,53 +109,35 @@ pub fn process_miners(
     drop(cons);
 }
 
-fn inc_level(miner: &mut Miner) {
-    miner.level = miner.level.saturating_add(1);
-
-    miner.inc = miner.inc.saturating_add(miner.level);
-
-    miner.pow = miner.pow.saturating_mul(10);
-}
-
-fn dec_level(miner: &mut Miner) {
-    miner.level = miner.level.saturating_sub(1);
-
-    miner.inc = miner.inc.saturating_sub(miner.level);
-
-    miner.pow = miner.pow.saturating_div(10);
-}
-
-pub fn add_idlecoins(mut wallet: &mut Wallet, new: u64) {
-    wallet.idlecoin = match wallet.idlecoin.checked_add(new) {
-        Some(c) => c,
-        None => {
-            wallet.supercoin = wallet.supercoin.saturating_add(1);
-            let x: u128 = (u128::from(wallet.idlecoin) + u128::from(new)) % u128::from(u64::MAX);
-            x as u64
+impl Miner {
+    pub fn new(wallet_id: u64, miner_id: u32) -> Miner {
+        Miner {
+            miner_id,
+            wallet_id,
+            level: 0,
+            cps: 0,
+            inc: 1,
+            pow: 10,
+            boost: 0,
         }
-    };
-}
+    }
 
-pub fn sub_idlecoins(mut wallet: &mut Wallet, less: u64) {
-    wallet.idlecoin = match wallet.idlecoin.checked_sub(less) {
-        Some(c) => c,
-        None => {
-            if wallet.supercoin > 0 {
-                wallet.supercoin = wallet.supercoin.saturating_sub(1);
-                (u128::from(u64::MAX) - u128::from(less) + u128::from(wallet.idlecoin))
-                    .try_into()
-                    .unwrap()
-            } else {
-                0
-            }
-        }
-    };
-}
+    pub fn inc_level(&mut self) {
+        self.level = self.level.saturating_add(1);
+        self.inc = self.inc.saturating_add(self.level);
+        self.pow = self.pow.saturating_mul(10);
+    }
 
+    pub fn dec_level(&mut self) {
+        self.level = self.level.saturating_sub(1);
+        self.inc = self.inc.saturating_sub(self.level);
+        self.pow = self.pow.saturating_div(10);
+    }
+}
 pub fn miner_session(mut miner: &mut Miner) {
     // Level up
     if miner.cps >= miner.pow {
-        inc_level(miner);
+        miner.inc_level();
     }
 
     // Increment cps

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -2,12 +2,25 @@ use crate::*;
 
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Wallet {
-    pub id: u64,         // wallet address ID
-    pub supercoin: u64,  // supercoin
-    pub idlecoin: u64,   // idlecoin
+    pub id: u64, // wallet address ID
+    #[serde(default = "def_zero")]
+    pub supercoin: u64, // supercoin
+    #[serde(default = "def_zero")]
+    pub idlecoin: u64, // idlecoin
+    #[serde(default = "def_zero")]
     pub chronocoin: u64, // chronocoin
-    pub randocoin: u64,  // randocoin
+    #[serde(default = "def_zero")]
+    pub randocoin: u64, // randocoin
+    #[serde(default = "def_five")]
     pub max_miners: u64, // max number of miners
+}
+
+fn def_zero() -> u64 {
+    0u64
+}
+
+fn def_five() -> u64 {
+    5u64
 }
 
 impl Wallet {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -22,4 +22,30 @@ impl Wallet {
         }
     }
 
+    pub fn add_idlecoins(&mut self, new: u64) {
+        self.idlecoin = match self.idlecoin.checked_add(new) {
+            Some(c) => c,
+            None => {
+                self.supercoin = self.supercoin.saturating_add(1);
+                let x: u128 = (u128::from(self.idlecoin) + u128::from(new)) % u128::from(u64::MAX);
+                x as u64
+            }
+        };
+    }
+
+    pub fn sub_idlecoins(&mut self, less: u64) {
+        self.idlecoin = match self.idlecoin.checked_sub(less) {
+            Some(c) => c,
+            None => {
+                if self.supercoin > 0 {
+                    self.supercoin = self.supercoin.saturating_sub(1);
+                    (u128::from(u64::MAX) - u128::from(less) + u128::from(self.idlecoin))
+                        .try_into()
+                        .unwrap()
+                } else {
+                    0
+                }
+            }
+        };
+    }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -51,16 +51,26 @@ impl Wallet {
     }
 
     pub fn inc_chronocoins(&mut self) {
-        self.chronocoin = match self.chronocoin.checked_add(1) {
+        self.chronocoin = self.chronocoin.saturating_add(1);
+    }
+
+    pub fn sub_chronocoins(&mut self, less: u64) -> Result<(), Error> {
+        self.chronocoin = match self.chronocoin.checked_sub(less) {
             Some(c) => c,
-            None => u64::MAX,
-        }
+            None => return Err(Error::new(ErrorKind::InvalidData, "Not enough chronocoin")),
+        };
+        Ok(())
     }
 
     pub fn inc_randocoins(&mut self) {
-        self.chronocoin = match self.chronocoin.checked_add(16) {
+        self.chronocoin = self.chronocoin.saturating_add(16);
+    }
+
+    pub fn sub_randocoins(&mut self, less: u64) -> Result<(), Error> {
+        self.randocoin = match self.randocoin.checked_sub(less) {
             Some(c) => c,
-            None => u64::MAX,
-        }
+            None => return Err(Error::new(ErrorKind::InvalidData, "Not enough randocoin")),
+        };
+        Ok(())
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -76,7 +76,7 @@ impl Wallet {
     }
 
     pub fn inc_randocoins(&mut self) {
-        self.chronocoin = self.chronocoin.saturating_add(16);
+        self.randocoin = self.randocoin.saturating_add(16);
     }
 
     pub fn sub_randocoins(&mut self, less: u64) -> Result<(), Error> {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -56,4 +56,11 @@ impl Wallet {
             None => u64::MAX,
         }
     }
+
+    pub fn inc_randocoins(&mut self) {
+        self.chronocoin = match self.chronocoin.checked_add(16) {
+            Some(c) => c,
+            None => u64::MAX,
+        }
+    }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -50,8 +50,8 @@ impl Wallet {
         Ok(())
     }
 
-    pub fn add_chronocoins(&mut self, add: u64) {
-        self.chronocoin = match self.chronocoin.checked_add(add) {
+    pub fn inc_chronocoins(&mut self) {
+        self.chronocoin = match self.chronocoin.checked_add(1) {
             Some(c) => c,
             None => u64::MAX,
         }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -33,7 +33,7 @@ impl Wallet {
         };
     }
 
-    pub fn sub_idlecoins(&mut self, less: u64) {
+    pub fn sub_idlecoins(&mut self, less: u64) -> Result<(), Error> {
         self.idlecoin = match self.idlecoin.checked_sub(less) {
             Some(c) => c,
             None => {
@@ -43,9 +43,17 @@ impl Wallet {
                         .try_into()
                         .unwrap()
                 } else {
-                    0
+                    return Err(Error::new(ErrorKind::InvalidData, "Not enough idlecoin"));
                 }
             }
         };
+        Ok(())
+    }
+
+    pub fn add_chronocoins(&mut self, add: u64) {
+        self.chronocoin = match self.chronocoin.checked_add(add) {
+            Some(c) => c,
+            None => u64::MAX,
+        }
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,0 +1,25 @@
+use crate::*;
+
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct Wallet {
+    pub id: u64,         // wallet address ID
+    pub supercoin: u64,  // supercoin
+    pub idlecoin: u64,   // idlecoin
+    pub chronocoin: u64, // chronocoin
+    pub randocoin: u64,  // randocoin
+    pub max_miners: u64, // max number of miners
+}
+
+impl Wallet {
+    pub fn new(id: u64) -> Wallet {
+        Wallet {
+            id,
+            supercoin: 0,
+            idlecoin: 0,
+            chronocoin: 0,
+            randocoin: 0,
+            max_miners: 5,
+        }
+    }
+
+}


### PR DESCRIPTION
Add Randocoin and Chronocoin!

Chronocoins are generated 1 per second per live wallet (a wallet with at least 1 connected miner). These coins can be spent in groups of `1000` to warp 1hr into the future. This grows the Miner, Miner level, Miner Cps, and total idlecoin as if an hour had actually passed.

Randocoins are assigned randomly in blocks of 16. No purpose has been assigned to these coins yet. 🙃 

Also a bunch of cleanup and rearranging of code.